### PR TITLE
[Bugfix] Button highlights: Thumbstick

### DIFF
--- a/POINT-VR-Chapter-1/Assets/POINT/InputAssets/Controls.inputactions
+++ b/POINT-VR-Chapter-1/Assets/POINT/InputAssets/Controls.inputactions
@@ -147,10 +147,10 @@
                 },
                 {
                     "name": "HighlightThumbstick",
-                    "type": "Button",
-                    "id": "49cda788-0635-4ded-b153-181c9fb22715",
-                    "expectedControlType": "Button",
-                    "processors": "",
+                    "type": "Value",
+                    "id": "62ee0e96-bd14-4eba-ad7e-27c491263b66",
+                    "expectedControlType": "Vector2",
+                    "processors": "StickDeadzone",
                     "interactions": ""
                 },
                 {
@@ -285,17 +285,6 @@
                 },
                 {
                     "name": "",
-                    "id": "2b32c8fc-7fac-4176-aca0-6c08cdcb5cb5",
-                    "path": "<XRController>{LeftHand}/thumbstickTouched",
-                    "interactions": "",
-                    "processors": "AxisDeadzone",
-                    "groups": "Generic XR Controller",
-                    "action": "HighlightThumbstick",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "889e8fe7-d6e9-49a0-a236-42a33dd96fbe",
                     "path": "<XRController>{LeftHand}/primaryButton",
                     "interactions": "",
@@ -346,6 +335,17 @@
                     "processors": "",
                     "groups": "Generic XR Controller",
                     "action": "HighlightGrip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "48d75b71-7cd9-4b96-b9fe-8c9fa8e8719d",
+                    "path": "<XRController>{LeftHand}/thumbstick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Generic XR Controller",
+                    "action": "HighlightThumbstick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }
@@ -413,10 +413,10 @@
                 },
                 {
                     "name": "HighlightThumbstick",
-                    "type": "Button",
+                    "type": "Value",
                     "id": "d34029bc-7170-4550-9206-f3b9285c28aa",
-                    "expectedControlType": "Button",
-                    "processors": "",
+                    "expectedControlType": "Vector2",
+                    "processors": "StickDeadzone",
                     "interactions": ""
                 },
                 {
@@ -596,9 +596,9 @@
                 {
                     "name": "",
                     "id": "b588aa2f-bc49-454e-9e20-fffa4febca81",
-                    "path": "<XRController>{RightHand}/thumbstickTouched",
+                    "path": "<XRController>{RightHand}/thumbstick",
                     "interactions": "",
-                    "processors": "AxisDeadzone",
+                    "processors": "",
                     "groups": "Generic XR Controller",
                     "action": "HighlightThumbstick",
                     "isComposite": false,

--- a/POINT-VR-Chapter-1/Assets/POINT/InputAssets/HighlightManager.cs
+++ b/POINT-VR-Chapter-1/Assets/POINT/InputAssets/HighlightManager.cs
@@ -37,8 +37,6 @@ public class HighlightManager : MonoBehaviour
         startBtnReference.action.Enable();
         triggerReference.action.Enable();
         gripReference.action.Enable();
-        thumbstickReference.action.started += (ctx) => { thumbstick.SetActive(true); } ;
-        thumbstickReference.action.canceled += (ctx) => { thumbstick.SetActive(false); };
         secondaryBtnReference.action.started += (ctx) => { secondaryBtn.SetActive(true); };
         secondaryBtnReference.action.canceled += (ctx) => { secondaryBtn.SetActive(false); };
         primaryBtnReference.action.started += (ctx) => { primaryBtn.SetActive(true); };
@@ -58,8 +56,6 @@ public class HighlightManager : MonoBehaviour
         startBtnReference.action.Disable();
         triggerReference.action.Disable();
         gripReference.action.Disable();
-        thumbstickReference.action.started -= (ctx) => { thumbstick.SetActive(true); };
-        thumbstickReference.action.canceled -= (ctx) => { thumbstick.SetActive(false); };
         secondaryBtnReference.action.started -= (ctx) => { secondaryBtn.SetActive(true); };
         secondaryBtnReference.action.canceled -= (ctx) => { secondaryBtn.SetActive(false); };
         primaryBtnReference.action.started -= (ctx) => { primaryBtn.SetActive(true); };
@@ -81,6 +77,11 @@ public class HighlightManager : MonoBehaviour
         {
             cameraTransform = Camera.current.transform;
         }
+
+        // Note: thumbstick input has to be read manually due to thumbstickTouched and thumbstickClicked
+        // in the Input Manager either ignoring deadzones or constantly being triggered
+        if (thumbstickReference.action.ReadValue<Vector2>().magnitude > 0.0f) thumbstick.SetActive(true);
+        else thumbstick.SetActive(false);
     }
 
     private void OnApplicationFocus(bool hasFocus)

--- a/POINT-VR-Chapter-1/Assets/POINT/InputAssets/Player.prefab
+++ b/POINT-VR-Chapter-1/Assets/POINT/InputAssets/Player.prefab
@@ -10920,7 +10920,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c3359bd4a3720747a0d5cb64cf0264c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  thumbstickReference: {fileID: 571498917463448294, guid: a54d6349e0e4d404fa09e1c0531de6d0,
+  thumbstickReference: {fileID: 6802790661191367748, guid: a54d6349e0e4d404fa09e1c0531de6d0,
     type: 3}
   secondaryBtnReference: {fileID: -5589238569535809175, guid: a54d6349e0e4d404fa09e1c0531de6d0,
     type: 3}


### PR DESCRIPTION
Button highlights should now work correctly for the thumbstick and take deadzones into account

Used Vector2 and read values on Update() to achieve this (since thumbstickTouched and thumbstickClicked did not seem to work)

Resolves #50 