### PR TITLE
Added faded endpoints to Scene 1

### DIFF
--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/CoordinateMass.prefab
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/CoordinateMass.prefab
@@ -79,7 +79,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded.meta
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44676260d22cc124997f7741da12abca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/EndpointFaded.prefab
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/EndpointFaded.prefab
@@ -28,7 +28,7 @@ Transform:
   m_GameObject: {fileID: 4761467784097608384}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.1789418, y: 1.4075956, z: 2}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/EndpointFaded.prefab
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/EndpointFaded.prefab
@@ -1,0 +1,95 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4761467784097608384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4761467784097608412}
+  - component: {fileID: 4761467784097608387}
+  - component: {fileID: 4761467784097608386}
+  - component: {fileID: 4761467784097608385}
+  m_Layer: 0
+  m_Name: EndpointFaded
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4761467784097608412
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4761467784097608384}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.1789418, y: 1.4075956, z: 2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4761467784097608387
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4761467784097608384}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4761467784097608386
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4761467784097608384}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9ad406c61cadf99489157273ddca88cc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &4761467784097608385
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4761467784097608384}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/EndpointFaded.prefab.meta
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/EndpointFaded.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 88c9ad1472e0a3a4eb30c13b036fe12c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.mat
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.mat
@@ -75,5 +75,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 0
     m_Colors:
-    - _Color: {r: 1, g: 0.981811, b: 0.9386792, a: 0.98039216}
+    - _Color: {r: 1, g: 0, b: 0.8352941, a: 0.5882353}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.mat
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.mat
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: FadeVolume
+  m_Shader: {fileID: 4800000, guid: 66287a0e68deb5b449e3293f3f6d467b, type: 3}
+  m_ShaderKeywords: _ALPHABLEND_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpAmt: 48
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 2
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _Size: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 5
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 1, g: 0.981811, b: 0.9386792, a: 0.98039216}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.mat.meta
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ad406c61cadf99489157273ddca88cc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.shader
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.shader
@@ -37,7 +37,7 @@
         {
             fixed4 c = _Color;
             o.Albedo = c.rgb;
-            o.Alpha = lerp(0.0, 1.0, pow(dot(IN.worldNormal, IN.viewDir), 4));
+            o.Alpha = lerp(0.0, c.a * 2.0, pow(dot(IN.worldNormal, IN.viewDir), 2));
         }
         ENDCG
     }

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.shader
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.shader
@@ -1,0 +1,45 @@
+﻿﻿Shader "Custom/FadeVolume"
+{
+    Properties
+    {
+        _Color ("Color", Color) = (1,1,1,1)
+    }
+    SubShader
+    {
+        Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+        LOD 200
+
+        CGPROGRAM
+        // Physically based Standard lighting model, and enable shadows on all light types
+        #pragma surface surf Standard fullforwardshadows addshadow alpha:fade
+
+        // Use shader model 3.0 target, to get nicer looking lighting
+        #pragma target 3.0
+
+        struct Input
+        {
+            float3 viewDir;
+            float3 worldNormal;
+        };
+
+        fixed4 _Color;
+
+        // Add instancing support for this shader. You need to check 'Enable Instancing' on materials that use the shader.
+        // See https://docs.unity3d.com/Manual/GPUInstancing.html for more information about instancing.
+        // #pragma instancing_options assumeuniformscaling
+        UNITY_INSTANCING_BUFFER_START(Props)
+            // put more per-instance properties here
+        UNITY_INSTANCING_BUFFER_END(Props)
+
+        void surf (Input IN, inout SurfaceOutputStandard o)
+        {
+            fixed4 c = _Color;
+            o.Albedo = c.rgb;
+            o.Alpha = lerp(0.0, 1.0, pow(dot(IN.worldNormal, IN.viewDir), 4));
+        }
+        ENDCG
+    }
+    FallBack "Diffuse"
+}

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.shader.meta
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndpointFaded/FadeVolume.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 66287a0e68deb5b449e3293f3f6d467b
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Ch1_one-mass-y.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Ch1_one-mass-y.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.0069632446, g: 0.0068257754, b: 0.007311784, a: 1}
+  m_IndirectSpecularColor: {r: 0.00695631, g: 0.006819715, b: 0.0073051304, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -174,7 +174,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Ch1_scene1.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Ch1_scene1.unity
@@ -387,7 +387,7 @@ Transform:
   m_GameObject: {fileID: 208592743}
   m_LocalRotation: {x: 0.5, y: 0.5, z: -0.5, w: 0.5}
   m_LocalPosition: {x: 0.5, y: 0, z: 0}
-  m_LocalScale: {x: 0.05, y: 0.425, z: 0.05}
+  m_LocalScale: {x: 0.05, y: 0.5, z: 0.05}
   m_Children: []
   m_Father: {fileID: 1362154959}
   m_RootOrder: 1
@@ -703,7 +703,7 @@ Transform:
   m_GameObject: {fileID: 348463229}
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 3, y: 1, z: 0.5}
-  m_LocalScale: {x: 0.05, y: 0.42500004, z: 0.050000004}
+  m_LocalScale: {x: 0.05, y: 0.5, z: 0.050000004}
   m_Children: []
   m_Father: {fileID: 982477345}
   m_RootOrder: 11
@@ -849,85 +849,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 353347864}
   m_CullTransparentMesh: 0
---- !u!1 &362375084
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 362375085}
-  - component: {fileID: 362375087}
-  - component: {fileID: 362375086}
-  m_Layer: 0
-  m_Name: EndPoint 4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &362375085
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 362375084}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3, y: 1, z: 0}
-  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
-  m_Children: []
-  m_Father: {fileID: 982477345}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &362375086
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 362375084}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 36a7b2cd125901a4189e0fd65cacef07, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &362375087
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 362375084}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &487090087
 GameObject:
   m_ObjectHideFlags: 0
@@ -1287,243 +1208,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea8e9b2d764e46d49b717e2c312ff485, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &642043160
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 642043161}
-  - component: {fileID: 642043163}
-  - component: {fileID: 642043162}
-  m_Layer: 0
-  m_Name: EndPoint 3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &642043161
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642043160}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3, y: 0, z: 0}
-  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
-  m_Children: []
-  m_Father: {fileID: 982477345}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &642043162
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642043160}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 36a7b2cd125901a4189e0fd65cacef07, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &642043163
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642043160}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &678724020
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 678724021}
-  - component: {fileID: 678724023}
-  - component: {fileID: 678724022}
-  m_Layer: 0
-  m_Name: EndPoint 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &678724021
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 678724020}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: 0, z: 0}
-  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
-  m_Children: []
-  m_Father: {fileID: 982477345}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &678724022
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 678724020}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 36a7b2cd125901a4189e0fd65cacef07, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &678724023
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 678724020}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &748440916
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 748440917}
-  - component: {fileID: 748440919}
-  - component: {fileID: 748440918}
-  m_Layer: 0
-  m_Name: EndPoint Final
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &748440917
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 748440916}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3, y: 1, z: 2}
-  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
-  m_Children: []
-  m_Father: {fileID: 982477345}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &748440918
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 748440916}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 36a7b2cd125901a4189e0fd65cacef07, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &748440919
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 748440916}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &764621877
 GameObject:
   m_ObjectHideFlags: 0
@@ -1598,7 +1282,7 @@ Transform:
   m_GameObject: {fileID: 764621877}
   m_LocalRotation: {x: 0.5, y: 0.5, z: -0.5, w: 0.5}
   m_LocalPosition: {x: 1.5, y: 0, z: 0}
-  m_LocalScale: {x: 0.05, y: 0.425, z: 0.05}
+  m_LocalScale: {x: 0.05, y: 0.5, z: 0.05}
   m_Children: []
   m_Father: {fileID: 982477345}
   m_RootOrder: 8
@@ -1688,8 +1372,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 845802304}
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 3, y: 1, z: 1.46}
-  m_LocalScale: {x: 0.05, y: 0.39000002, z: 0.050000004}
+  m_LocalPosition: {x: 3, y: 1, z: 1.5}
+  m_LocalScale: {x: 0.05, y: 0.5, z: 0.050000004}
   m_Children: []
   m_Father: {fileID: 982477345}
   m_RootOrder: 12
@@ -2011,6 +1695,96 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb007caf687da994a9593ad3fd67eb7e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &909988860
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 982477345}
+    m_Modifications:
+    - target: {fileID: 4761467784097608384, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_Name
+      value: Endpoint Final
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 88c9ad1472e0a3a4eb30c13b036fe12c, type: 3}
+--- !u!4 &909988861 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+    type: 3}
+  m_PrefabInstance: {fileID: 909988860}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &982477343
 GameObject:
   m_ObjectHideFlags: 0
@@ -2038,12 +1812,12 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 5607564394970488419}
-  - {fileID: 678724021}
-  - {fileID: 642043161}
-  - {fileID: 362375085}
-  - {fileID: 1568121784}
-  - {fileID: 748440917}
+  - {fileID: 1511521056}
+  - {fileID: 1479087878}
+  - {fileID: 1960743726}
+  - {fileID: 1448834687}
+  - {fileID: 1401604033}
+  - {fileID: 909988861}
   - {fileID: 605576148}
   - {fileID: 1216784205}
   - {fileID: 764621881}
@@ -2227,7 +2001,7 @@ Transform:
   m_GameObject: {fileID: 1126574971}
   m_LocalRotation: {x: 0.5, y: 0.5, z: -0.5, w: 0.5}
   m_LocalPosition: {x: 2.5, y: 0, z: 0}
-  m_LocalScale: {x: 0.05, y: 0.425, z: 0.05}
+  m_LocalScale: {x: 0.05, y: 0.5, z: 0.05}
   m_Children: []
   m_Father: {fileID: 982477345}
   m_RootOrder: 9
@@ -2470,7 +2244,7 @@ Transform:
   m_GameObject: {fileID: 1216784201}
   m_LocalRotation: {x: 0.5, y: 0.5, z: -0.5, w: 0.5}
   m_LocalPosition: {x: 0.5, y: 0, z: 0}
-  m_LocalScale: {x: 0.05, y: 0.425, z: 0.05}
+  m_LocalScale: {x: 0.05, y: 0.5, z: 0.05}
   m_Children: []
   m_Father: {fileID: 982477345}
   m_RootOrder: 7
@@ -2680,6 +2454,366 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1401604032
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 982477345}
+    m_Modifications:
+    - target: {fileID: 4761467784097608384, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_Name
+      value: Endpoint 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 88c9ad1472e0a3a4eb30c13b036fe12c, type: 3}
+--- !u!4 &1401604033 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1401604032}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1448834686
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 982477345}
+    m_Modifications:
+    - target: {fileID: 4761467784097608384, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_Name
+      value: Endpoint 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 88c9ad1472e0a3a4eb30c13b036fe12c, type: 3}
+--- !u!4 &1448834687 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1448834686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1479087877
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 982477345}
+    m_Modifications:
+    - target: {fileID: 4761467784097608384, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_Name
+      value: Endpoint 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 88c9ad1472e0a3a4eb30c13b036fe12c, type: 3}
+--- !u!4 &1479087878 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1479087877}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1511521055
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 982477345}
+    m_Modifications:
+    - target: {fileID: 4761467784097608384, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_Name
+      value: Endpoint 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 88c9ad1472e0a3a4eb30c13b036fe12c, type: 3}
+--- !u!4 &1511521056 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1511521055}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1517120594
 GameObject:
   m_ObjectHideFlags: 0
@@ -2814,85 +2948,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1517120594}
   m_CullTransparentMesh: 0
---- !u!1 &1568121783
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1568121784}
-  - component: {fileID: 1568121786}
-  - component: {fileID: 1568121785}
-  m_Layer: 0
-  m_Name: EndPoint 5
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1568121784
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1568121783}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3, y: 1, z: 1}
-  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
-  m_Children: []
-  m_Father: {fileID: 982477345}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &1568121785
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1568121783}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 36a7b2cd125901a4189e0fd65cacef07, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1568121786
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1568121783}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1576100407
 GameObject:
   m_ObjectHideFlags: 0
@@ -2967,7 +3022,7 @@ Transform:
   m_GameObject: {fileID: 1576100407}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 3, y: 0.5, z: 0}
-  m_LocalScale: {x: 0.05, y: 0.425, z: 0.05}
+  m_LocalScale: {x: 0.05, y: 0.5, z: 0.05}
   m_Children: []
   m_Father: {fileID: 982477345}
   m_RootOrder: 10
@@ -3257,6 +3312,96 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1960743725
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 982477345}
+    m_Modifications:
+    - target: {fileID: 4761467784097608384, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_Name
+      value: Endpoint 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 88c9ad1472e0a3a4eb30c13b036fe12c, type: 3}
+--- !u!4 &1960743726 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4761467784097608412, guid: 88c9ad1472e0a3a4eb30c13b036fe12c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1960743725}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2026671532
 GameObject:
   m_ObjectHideFlags: 0
@@ -4058,82 +4203,3 @@ PrefabInstance:
       objectReference: {fileID: 1804311721}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2011726434ab5504db0591931cd0ea01, type: 3}
---- !u!33 &5607564394970488418
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5607564394970488422}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &5607564394970488419
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5607564394970488422}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1, y: 0, z: 0}
-  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
-  m_Children: []
-  m_Father: {fileID: 982477345}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &5607564394970488421
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5607564394970488422}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 36a7b2cd125901a4189e0fd65cacef07, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!1 &5607564394970488422
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5607564394970488419}
-  - component: {fileID: 5607564394970488418}
-  - component: {fileID: 5607564394970488421}
-  m_Layer: 0
-  m_Name: EndPoint 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Ch1_scene1.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Ch1_scene1.unity
@@ -1490,7 +1490,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -3170,7 +3170,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Ch1_two-masses.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Ch1_two-masses.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.0069632446, g: 0.0068257754, b: 0.007311784, a: 1}
+  m_IndirectSpecularColor: {r: 0.00695631, g: 0.006819715, b: 0.0073051304, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -175,7 +175,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Tutorial.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter1/Tutorial.unity
@@ -175,7 +175,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter2/Chapter2.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Chapter2/Chapter2.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.006960895, g: 0.0068234773, b: 0.0073094447, a: 1}
+  m_IndirectSpecularColor: {r: 0.00695631, g: 0.006819715, b: 0.0073051304, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -175,7 +175,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Conference Demos/ConfDemo_part1_one-mass-y.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Conference Demos/ConfDemo_part1_one-mass-y.unity
@@ -175,7 +175,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Conference Demos/ConfDemo_part3_ranking-masses.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Conference Demos/ConfDemo_part3_ranking-masses.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.0069632446, g: 0.0068257754, b: 0.007311784, a: 1}
+  m_IndirectSpecularColor: {r: 0.00695631, g: 0.006819715, b: 0.0073051304, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2849,7 +2849,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -4163,7 +4163,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Feature-2.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Feature-2.unity
@@ -188,7 +188,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Old/Chapter1.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Old/Chapter1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.0069632446, g: 0.0068257754, b: 0.007311784, a: 1}
+  m_IndirectSpecularColor: {r: 0.00695631, g: 0.006819715, b: 0.0073051304, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -175,7 +175,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f874c83a94b18624b8db4a48f725f34a, type: 2}
+  - {fileID: 2100000, guid: 3d12a53ab8595fc47825a0ac1ae1c035, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0


### PR DESCRIPTION
Goal: To try to make it clearer to players that they can't "skip" endpoints (implication is that if an endpoint is "faded", it isn't actually there yet so the player can't drag the mass there)

Also includes converting all yellow mass sphere materials to opaque version