### PR TITLE
Endpoint Line Bug

### DIFF
--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndPointManager.cs
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/EndPointManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Net;
+using M = System.Math;
 using UnityEngine;
 
 /// <summary>
@@ -76,9 +77,9 @@ public class EndPointManager : MonoBehaviour
                     triggered = false;
                     break;
                 }
-                if (pos != new Vector3(0,0,0)) // Adds endpoint to endPath list if it is triggered and is not the origin
+                if (pos != new Vector3(0,0,0) || endPath.Count > 0) // Adds endpoint to endPath list if it is triggered and is not the origin in the beginning
                 {
-                    endPath.Add(pos);
+                    endPath.Add(new Vector3((int) (M.Round(pos.x)), (int) (M.Round(pos.y)), (int) (M.Round(pos.z))));
                 }
                 if (comparePoints.Count >= 1 && endPath.Count >= 1 && moveLimit == false) // Makes sure comparison is only done on the second go-through, and when
                 {                                                                        // the player has not had their previous run go over 12 moves, if it has

--- a/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/Scene1Manager.cs
+++ b/POINT-VR-Chapter-1/Assets/POINT/4D-SpacetimeAssets/Scene1Manager.cs
@@ -214,12 +214,12 @@ public class Scene1Manager : MonoBehaviour
                 var newPathLine = Instantiate(secondPath.transform.GetChild(1).gameObject, new Vector3(v.x / 2, v.y / 2, v.z / 2), Quaternion.identity, secondPath.transform);
                 // if the line will be along y axis then that is how it is originally
                 // along x axis
-                if (v.x > 0)
+                if (v.x != 0)
                 {
                     newPathLine.transform.Rotate(0.0f, 0.0f, 90.0f, Space.Self);
                 }
                 // along z axis
-                if (v.z > 0)
+                if (v.z != 0)
                 {
                     newPathLine.transform.Rotate(90.0f, 0.0f, 0.0f, Space.Self);
                 }


### PR DESCRIPTION
Fixed bug during the endpoint activity in which the line segments may have been oriented in the wrong direction. There were 3 causes for this that have all been fixed:
1. Going backwards to start caused the line segment to not be rotated at all
2. Going back through the origin caused the line segment to instead be between the point before and after the origin
3. Decimal precision errors caused line segments to be oriented randomly

All of these cases should be fixed and they were tested to all work correctly.