### PR TITLE
Bugfix arrows audio

### DIFF
--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Conference Demos/ConfDemo_part1_one-mass-y.unity
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Conference Demos/ConfDemo_part1_one-mass-y.unity
@@ -475,7 +475,7 @@ PrefabInstance:
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
       propertyPath: onCast.m_PersistentCalls.m_Calls.Array.size
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
@@ -663,7 +663,7 @@ PrefabInstance:
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
       propertyPath: onCast.m_PersistentCalls.m_Calls.Array.size
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
@@ -683,7 +683,7 @@ PrefabInstance:
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
       propertyPath: onCast.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
@@ -693,7 +693,7 @@ PrefabInstance:
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
       propertyPath: onCast.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: CheckArrowTask
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
@@ -1928,7 +1928,7 @@ PrefabInstance:
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
       propertyPath: onCast.m_PersistentCalls.m_Calls.Array.size
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
@@ -2174,7 +2174,7 @@ PrefabInstance:
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
       propertyPath: onCast.m_PersistentCalls.m_Calls.Array.size
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
@@ -2314,7 +2314,7 @@ PrefabInstance:
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
       propertyPath: onCast.m_PersistentCalls.m_Calls.Array.size
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
@@ -2719,7 +2719,7 @@ PrefabInstance:
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}
       propertyPath: onCast.m_PersistentCalls.m_Calls.Array.size
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1128561483501416258, guid: b67bcc037869c8245a2348ffee62f596,
         type: 3}

--- a/POINT-VR-Chapter-1/Assets/POINT/Scenes/Conference Demos/ConfDemo_part1_one_mass_y_manager.cs
+++ b/POINT-VR-Chapter-1/Assets/POINT/Scenes/Conference Demos/ConfDemo_part1_one_mass_y_manager.cs
@@ -116,6 +116,9 @@ public class ConfDemo_part1_one_mass_y_manager : MonoBehaviour
         yield return new WaitForSeconds(2);
         player.GetComponent<NarrationManager>().PlayClipWithSubtitles("Chapter1Scene2\\3_direction_of_curvature_arrow_5");
         yield return new WaitForSeconds(6.1f);
+        // wait for player to reach correct arrow orientation
+        yield return new WaitUntil(() => CheckArrowTask());
+        StartCoroutine(StartScenePart2());
     }
 
     private void ArrowTask()
@@ -123,14 +126,16 @@ public class ConfDemo_part1_one_mass_y_manager : MonoBehaviour
         setOfDirectionalArrows.SetActive(true);  // spawn six directional arrows
     }
 
-    public void CheckArrowTask()
+    public bool CheckArrowTask()
     {
         foreach (DirectionalArrow directionalArrow in directionalArrows)
         {
-            if (!directionalArrow.IsCorrect) return;
+            if (!directionalArrow.IsCorrect) {
+                return false;
+            }
         }
 
-        StartCoroutine(StartScenePart2());
+        return true;
     }
 
     private IEnumerator StartScenePart2()


### PR DESCRIPTION
Summary: This task is a bugfix in response to the GitHub Issue: #91. The cause of this issue is that the directional arrows in Scene 2 continuously call the function CheckArrowTask() which starts the next coroutine when the directional arrows have been pointed correctly. This function can still be called after initial completion by undoing and recompleting the task, restarting the coroutine and giving the appearance of overlaying audio. A video of this effect is found here: https://drive.google.com/file/d/1WJt6KGXown9MXiG5lTWtymnX1kLYldfz/view?usp=sharing

Fix:
- Reworked Arrows Task to simply wait until the first completion and then move forward to the next coroutine. This stops CheckArrowTask() from being called again later and restarting the coroutine as was happening with the bug.
- Removed the CheckArrowTask() script from the Directional Arrows as they do not need to call this anymore. It is now taken care of by the Wait Until statement in the scene manager.
- Added APK file for testing this bugfix.

Something To Think About:
- With this new change, following the completion of this activity and entering of the next coroutine, the player can still rotate the arrows and put them in an incorrect configuration as the next audio lines are playing out which talk about the arrows pointing towards the sphere. For now, I am assuming this is the desired behavior, but this can be changed.