### PR TITLE
Working Scene References

### DIFF
--- a/POINT-VR-Chapter-1/Assets/POINT/InputAssets/SceneController.cs
+++ b/POINT-VR-Chapter-1/Assets/POINT/InputAssets/SceneController.cs
@@ -10,13 +10,13 @@ using System.Collections.Generic;
 /// </summary>
 public enum SceneNumEnum
 {
-    StartMenu = 900,
-    Tutorial = 901,
-    Ch1_Scene1 = 902,
-    Conf_Demo_P1 = 903,
-    Conf_Demo_P2 = 904,
-    Conf_Demo_P3 = 905,
-    EndCredits = 906
+    StartMenu = 114,
+    Tutorial = 97,
+    Ch1_Scene1 = 115,
+    Conf_Demo_P1 = 116,
+    Conf_Demo_P2 = 108,
+    Conf_Demo_P3 = 101,
+    EndCredits = 121
 }
 
 /// <summary>

--- a/POINT-VR-Chapter-1/Assets/POINT/InputAssets/SceneController.cs
+++ b/POINT-VR-Chapter-1/Assets/POINT/InputAssets/SceneController.cs
@@ -1,6 +1,24 @@
 ﻿using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using System.Collections.Generic;
+
+/// <summary>
+/// Stores integer values under scene names. Do not change these intergers (you should be changing the SceneDict dictionary below). Integers are linked to build settings scene integers in the dictionary SceneDict (defined in SceneController).
+/// There are two layers of this (enum here, and the dict down below) because the Unity Editor stores the value of the enum, not its name. So if the build settings change and you change the enum in the code then what the editor stores
+/// won't actually change. 
+/// </summary>
+public enum SceneNumEnum
+{
+    StartMenu = 900,
+    Tutorial = 901,
+    Ch1_Scene1 = 902,
+    Conf_Demo_P1 = 903,
+    Conf_Demo_P2 = 904,
+    Conf_Demo_P3 = 905,
+    EndCredits = 906
+}
+
 /// <summary>
 /// This script should be on the player prefab. It communicates the player's setting to the GameManager before switching scenes and then retrieves this information upon being instantiated.
 /// </summary>
@@ -50,6 +68,21 @@ public class SceneController : MonoBehaviour
     /// <summary>
     /// When Instantiated: Get the player data. Communicate this data to all component arguments.
     /// </summary>
+
+    /// <summary>
+    /// Relates the shown enum (left) to scene numbers in build settings. If the scene numbers in build settings change you should update
+    /// the right side of the dictionary (the values) with the new numbers. 
+    /// </summary>
+    private Dictionary<int, int> SceneDict = new Dictionary<int, int>
+    {
+        { (int) SceneNumEnum.StartMenu, 0 },
+        { (int) SceneNumEnum.Tutorial, 1 },
+        { (int) SceneNumEnum.Ch1_Scene1, 2 },
+        { (int) SceneNumEnum.Conf_Demo_P1, 3 },
+        { (int) SceneNumEnum.Conf_Demo_P2, 4 },
+        { (int) SceneNumEnum.Conf_Demo_P3, 5 },
+        { (int) SceneNumEnum.EndCredits, 6 }
+    };
     private void Start()
     {
         GameManager.PlayerData data = GameManager.Instance.GetData();
@@ -58,7 +91,7 @@ public class SceneController : MonoBehaviour
         functional.value = data.functionalVolume;
         aesthetic.value = data.aestheticVolume;
         uiManager.Language = (int)data.language;
-        uiManager.SubtitleLanguage = (int) data.subtitleLanguage;
+        uiManager.SubtitleLanguage = (int)data.subtitleLanguage;
         music.mute = false;
         floorToggle.IsOn = data.isFloorVisible;
         hapticToggle.IsOn = data.isHapticsEnabled;
@@ -81,10 +114,16 @@ public class SceneController : MonoBehaviour
             isHapticsEnabled = hapticToggle.IsOn,
             isControllerHighlighted = highlightsToggle.IsOn,
             language = (GameManager.Language)uiManager.Language,
-            subtitleLanguage = (GameManager.Language) uiManager.SubtitleLanguage
+            subtitleLanguage = (GameManager.Language)uiManager.SubtitleLanguage
         };
         GameManager.Instance.SetData(data);
         pause.Unpause();
         SceneManager.LoadScene(scene);
+    }
+
+    // Using a function here so the dictionary can't be modified and we don't have to bother passing larger object (I lack C# knowledge; there may be a better way to do this)
+    public int OperateSceneDict(int SceneNumEnum_number)
+    {
+        return SceneDict[SceneNumEnum_number];
     }
 }

--- a/POINT-VR-Chapter-1/Assets/POINT/InputAssets/StartMenuManager.cs
+++ b/POINT-VR-Chapter-1/Assets/POINT/InputAssets/StartMenuManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -23,6 +24,11 @@ public class StartMenuManager : MonoBehaviour
 
     [Tooltip("Default localized string that appears under current objective in the UI menu")]
     [SerializeField] private LocalizedString defaultObjective;
+
+    [SerializeField] SceneNumEnum Tutorial_Enum;
+
+    [SerializeField] SceneNumEnum End_Credits_Enum;
+
 
     /// <summary>
     /// A reference to the player GameObject
@@ -242,7 +248,7 @@ public class StartMenuManager : MonoBehaviour
             SceneController sceneController = player.GetComponentInChildren<SceneController>();
             if (sceneController != null)
             {
-                sceneController.ChangeScene(1);
+                sceneController.ChangeScene(sceneController.OperateSceneDict((int) Tutorial_Enum));
             }
         }
     }
@@ -271,7 +277,7 @@ public class StartMenuManager : MonoBehaviour
             SceneController sceneController = player.GetComponentInChildren<SceneController>();
             if (sceneController != null)
             {
-                sceneController.ChangeScene(6);
+                sceneController.ChangeScene(sceneController.OperateSceneDict((int) End_Credits_Enum));
             }
         }
     }


### PR DESCRIPTION
Working scene references on my end, hopefully it works for y'all too. In addition to SceneController.cs and StartMenuManager.cs I modified the Scene UI Container in the StartMenu scene to use the scene references (see screenshot), but I didn't add the file because I don't trust myself not to have accidentally edited other important things. I figure it'd be a lot safer if one of you guys went in and made the change when testing.
<img width="960" alt="image" src="https://github.com/user-attachments/assets/ca61eafd-8b52-4307-9d86-926d3d82f3d2" />

I don't know of any other magic numbers for changing scenes, but it's possible some still exist in the codebase that I don't know of.

Sorry for not explaining how I did this. I have to go to bed, and hope you guys can look at the code changes and get a general sense. If any parts of the implementation + the comments I wrote don't make sense, just reply to this and I can clarify tomorrow.

But for a quick comment on that, the core setup is in SceneController, and StartMenuManager is an example of how to use the scene references.